### PR TITLE
add local rpc api auth func so server doesnt complain

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,13 @@ module.exports = function (keys, config) {
   //if we are in the browser
   config = config || {}
   config.host = config.host || 'localhost'
-  var client = muxrpc(loadManf(config), false, serialize)()
+  
+  var client = muxrpc(loadManf(config), { auth: 'async' }, serialize)({
+    auth: function (req, cb) {
+      // just pass-through. you're authed!
+      cb()
+    }
+  })
   client.keys = keys
 
   var wsStream


### PR DESCRIPTION
Scuttlebot tries to auth with all incoming connections, which, for applications, results in a stackdump like this:

```
warn dDZA SBOT 1 unauthed
  Error: method not supported:auth
      at Object.PacketStream.request (/Users/paulfrazee/ssb-client/node_modules/muxrpc/index.js:72:23)
      at onRequest (/Users/paulfrazee/ssb-client/node_modules/muxrpc/node_modules/packet-stream/index.js:26:12)
      at Object.p.write (/Users/paulfrazee/ssb-client/node_modules/muxrpc/node_modules/packet-stream/index.js:181:33)
      at /Users/paulfrazee/ssb-client/node_modules/muxrpc/pull-weird.js:52:15
      at loop (/Users/paulfrazee/ssb-client/node_modules/pull-stream/sinks.js:15:33)
      at /Users/paulfrazee/ssb-client/node_modules/pull-stream/throughs.js:97:9
      at /Users/paulfrazee/ssb-client/node_modules/pull-stream/throughs.js:97:9
      at /Users/paulfrazee/ssb-client/node_modules/pull-stream/throughs.js:21:7
      at pull (/Users/paulfrazee/ssb-client/node_modules/pull-serializer/node_modules/pull-split/node_modules/pull-through/index.js:35:9)
      at next (/Users/paulfrazee/ssb-client/node_modules/pull-serializer/node_modules/pull-split/node_modules/pull-through/node_modules/looper/index.js:7:11)
```

this looks a whole lot like an error to users, so I suggest this PR so that scuttlebot feels nice and authed