### PR TITLE
Remove crypto from ssb-client repo, use existing libraries instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,37 @@
 
 ```js
 
-var Client = require('./')
-
-var config  = require('ssb-config')
+var Client = require('ssb-client')
 var ssbKeys = require('ssb-keys')
-var keys = ssbKeys.loadOrCreateSync(config)
 
-function abortIf (err) {
-  if(err) throw err
+// desktop app:
+var keys = ssbKeys.loadOrCreateSync('./app-private.key')
+
+// web app:
+var keys
+try {
+  keys = JSON.parse(localStorage.keys)
+} catch (e) {
+  keys = ssbKeys.generate()
+  localStorage.keys = JSON.stringify(keys)
 }
 
 var client = Client(keys, config)
-  .connect(abortIf) //auth is automatic
+  .connect(abortIf)
+  .auth(ssbKeys.createAuth(keys), abortIf)
 
-client.publish({
+var feed = client.createFeed(keys)
+feed.add({
   type: 'post', text: 'hello, world!'
 }, function (err, msg) {
   abortIf(err)
   console.log(msg)
   client.close()
 })
+
+function abortIf (err) {
+  if(err) throw err
+}
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pull-ws-server": "~1.3.0",
     "secure-scuttlebutt": "~9.0.1",
     "ssb-address": "~1.0.0",
-    "ssb-keys": "~0.5.0",
+    "ssb-keys": "~0.6.0",
     "ssb-manifest": "~1.1.0",
     "ssb-config": "~1.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -11,12 +11,12 @@ tape('test api', function (t) {
 
   var keys = ssbkeys.generate()
   var client = ssbclient(keys)
-  client.connect({ port: 45451, host: 'localhost' }, function (err) {
-    if (err)
-      throw err
-  })
-  client.publish({type: 'post', text: 'hello'}, function (err, data) {
-    if(err) throw err
+  client.connect({ port: 45451, host: 'localhost' }, iferr)
+  client.auth(ssbkeys.createAuth(keys), iferr)
+
+  var feed = client.createFeed(keys)
+  feed.add({type: 'post', text: 'hello'}, function (err, data) {
+    iferr(err)
     t.equal(data.value.content.text, 'hello')
     console.log(data)
     client.close(function() {
@@ -24,4 +24,9 @@ tape('test api', function (t) {
       t.end()
     })
   })
+
+  function iferr (err) {
+    if (err)
+      throw err
+  }
 })


### PR DESCRIPTION
per https://github.com/ssbc/ssb-client/issues/2

@dominictarr I also updated the readme to show key management for desktop and web apps. The existing readme would have the app use sbot's main feed keys, which we don't want. You have any objections to what I did instead?