### PR TITLE
tools for configuring the client's feed as an application alias-feed of the user's main feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ var client = SSBClient({ host: 'localhost' })
   .connect(abortIf)
   .auth(SSBKeys.createAuth(keys), abortIf)
 
+// create and configure feed:
+var feed = client.createFeed(keys, { name: 'My Application' }, function (err, msgs) {
+  if (msgs.length > 0) {
+    // ssb-client published new 'contact' messages for the feed
+    console.log(msgs)
+  } else {
+    // feed's information was already published on the feed
+  }
+})
+
 // post to feed:
-var feed = client.createFeed(keys)
 feed.add({
   type: 'post', text: 'hello, world!'
 }, function (err, msg) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/ssbc/ssb-client.git"
   },
   "dependencies": {
+    "explain-error": "~1.0.1",
     "muxrpc": "~3.3.1",
     "pull-stream": "~2.26.0",
     "pull-serializer": "~0.3.2",
@@ -22,11 +23,11 @@
     "ssb-config": "~1.0.0"
   },
   "devDependencies": {
-    "levelup": "~0.19.0",
-    "level-sublevel": "~6.4.6",
-    "memdown": "~1.0.0",
-    "scuttlebot": "~3.0.0",
-    "tape": "~2.12.3"
+     "levelup": "~0.19.0",
+     "level-sublevel": "~6.4.6",
+     "memdown": "~1.0.0",
+     "scuttlebot": "~3.0.0",
+     "tape": "~2.12.3"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT",

--- a/test/index.js
+++ b/test/index.js
@@ -1,32 +1,72 @@
+var pull = require('pull-stream')
 var scuttlebot = require('scuttlebot')
 var ssbkeys = require('ssb-keys')
 var tape = require('tape')
 var ssbclient = require('../index')
 
-tape('test api', function (t) {
-
-  var db = require('level-sublevel')(require('levelup')('/testdb', { db: require('memdown') }))
+function setupTest () {
+  var db = require('level-sublevel/bytewise')(require('levelup')('/testdb', { db: require('memdown'), keyEncoding: 'json', valueEncoding: 'json' }))
   var ssb = require('secure-scuttlebutt')(db, require('secure-scuttlebutt/defaults'))
   var server = scuttlebot({ port: 45451, host: 'localhost' }, ssb, ssb.createFeed()).use(require('scuttlebot/plugins/logging'))
 
   var keys = ssbkeys.generate()
-  var client = ssbclient(keys)
-  client.connect({ port: 45451, host: 'localhost' }, iferr)
+  var client = ssbclient({ port: 45451, host: 'localhost' })
+  client.connect(iferr)
   client.auth(ssbkeys.createAuth(keys), iferr)
 
-  var feed = client.createFeed(keys)
+  return {
+    server: server,
+    client: client,
+    keys: keys
+  }
+}
+
+function iferr (err) {
+  if (err)
+    throw err
+}
+
+tape('add messages', function (t) {
+
+  var env = setupTest()
+  var feed = env.client.createFeed(env.keys)
+
   feed.add({type: 'post', text: 'hello'}, function (err, data) {
     iferr(err)
     t.equal(data.value.content.text, 'hello')
     console.log(data)
-    client.close(function() {
-      server.close()
+    env.client.close(function() {
+      env.server.close()
       t.end()
     })
   })
+})
 
-  function iferr (err) {
-    if (err)
-      throw err
-  }
+tape('publish contact and feed-alias info', function (t) {
+
+  var env = setupTest()
+  env.client.createFeed(env.keys, { name: 'test app' }, function (err, msgs) {
+    iferr(err)
+    // 2 messages, one about self and one about the user feed
+    t.equal(msgs.length, 2)
+    console.log(msgs.map(function (msg) { return msg.value.content }))
+
+    env.client.createFeed(env.keys, { name: 'test app!' }, function (err, msgs) {
+      iferr(err)
+      // 1 message updating self
+      t.equal(msgs.length, 1)
+      console.log(msgs.map(function (msg) { return msg.value.content }))
+
+      env.client.createFeed(env.keys, { name: 'test app!' }, function (err, msgs) {
+        iferr(err)
+        // no messages shouldve been published this time
+        t.equal(msgs.length, 0)
+
+        env.client.close(function() {
+          env.server.close()
+          t.end()
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
Per https://github.com/ssbc/phoenix/issues/340, it's necessary for application feeds to alias themselves to the user's main feed. To accomplish this, the application needs to know what info it wants to have published about itself and that alias, find out what has been published already, and then reconcile the two by publishing new messages as needed.

In another issue, we're discussing moving `createFeed` to another repo. However, it's a natural place for this code to be be, so for the sake of having something to start with, I used that function.

Here's the example use the readme shows:

```js
// connect:
var client = SSBClient({ host: 'localhost' })
  .connect(abortIf)
  .auth(SSBKeys.createAuth(keys), abortIf)

// create and configure feed:
var feed = client.createFeed(keys, { name: 'My Application' }, function (err, msgs) {
  if (msgs.length > 0) {
    // ssb-client published new 'contact' messages for the feed
    console.log(msgs)
  } else {
    // feed's information was already published on the feed
  }
})
```

This new version of `createFeed` checks for `type: contact` messages which alias the feed to the main sbot feed, and for `type: contact` messages to self which set the name to what's given, and the `role` attr to `app`. If either are missing, the messages are created.