### PR TITLE
Enable noauth transform via ws transport

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,9 @@ module.exports = function (keys, opts, cb) {
     [Net({}), NoAuth({
       keys: toSodiumKeys(keys)
     })],
+    [WS({}), NoAuth({
+      keys: toSodiumKeys(keys)
+    })]
   ])
 
   ms.client(remote, function (err, stream) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ssb-keys": "^7.0.13"
   },
   "devDependencies": {
-    "scuttlebot": "^7.3.4",
+    "scuttlebot": "latest",
     "tape": "^4.2.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,8 @@ var server = ssbServer({
   appKey: shsCap
 })
 
+// ssbServer() is sync function but does not actually guarantee to have a working server instance when it retruns :(
+setTimeout( function() { 
 tape('connect', function (t) {
 
   ssbClient(keys, { port: 45451, manifest: server.manifest(), caps: { shs: shsCap }}, function (err, client) {
@@ -33,5 +35,5 @@ tape('connect', function (t) {
       process.exit(0)
     })
   })
-
 })
+}, 10)


### PR DESCRIPTION
Also makes sure travis tests against the latest version of scuttlebot by
using "latest" tag in package.json
(a regression in sbot@12 was not caught, because the client was tested
against an outdated version of sbot)