### PR TITLE
update multiserver (major versions), and update tests to use ssb-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ssb-client v2
 
-[Scuttlebot](https://github.com/ssbc/scuttlebot) client. 
+A scuttlebot ([ssb-server](https://github.com/ssbc/ssb-server)) client. 
 
 Create an rpc connection to an sbot running locally. 
 
@@ -52,7 +52,7 @@ See [ssb-keys](https://github.com/ssbc/ssb-keys). The keys look like this:
 ```
 
 ### caps
-`caps.shs` is a random string passed to [secret-handshake](https://github.com/auditdrivencrypto/secret-handshake#example). It determines which sbot you are able to connect to. It defaults to a magic string in this repo and also in [scuttlebot](https://github.com/ssbc/scuttlebot/blob/master/lib/ssb-cap.js)
+`caps.shs` is a random string passed to [secret-handshake](https://github.com/auditdrivencrypto/secret-handshake#example). It determines which sbot you are able to connect to. It defaults to a magic string in this repo and also in [ssb-server](https://github.com/ssbc/ssb-server/blob/master/lib/ssb-cap.js)
 
 ```js
 var appKey = new Buffer(opts.caps.shs, 'base64')

--- a/index.js
+++ b/index.js
@@ -21,9 +21,9 @@ function toSodiumKeys(keys) {
   if(!keys || !keys.public) return null
   return {
     publicKey:
-      new Buffer(keys.public.replace('.ed25519',''), 'base64'),
+      Buffer.from(keys.public.replace('.ed25519',''), 'base64'),
     secretKey:
-      new Buffer(keys.private.replace('.ed25519',''), 'base64'),
+      Buffer.from(keys.private.replace('.ed25519',''), 'base64'),
   }
 }
 
@@ -49,7 +49,7 @@ module.exports = function (keys, opts, cb) {
   keys = keys || ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))
   opts = opts || {}
 
-  var appKey = new Buffer(config.caps.shs, 'base64')
+  var appKey = Buffer.from(config.caps.shs, 'base64')
 
   var remote
   if(opts.remote)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ssb-keys": "^7.0.13"
   },
   "devDependencies": {
-    "ssb-server": "^13.5.2",
+    "ssb-server": "latest",
     "tape": "^4.2.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "explain-error": "^1.0.1",
     "multicb": "^1.2.1",
-    "multiserver": "^1.13.2",
+    "multiserver": "^3.0.2",
     "muxrpc": "^6.4.0",
     "pull-hash": "^1.0.0",
     "pull-stream": "^3.6.0",
@@ -21,7 +21,7 @@
     "ssb-keys": "^7.0.13"
   },
   "devDependencies": {
-    "scuttlebot": "^7.3.4",
+    "ssb-server": "^13.5.2",
     "tape": "^4.2.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ssb-keys": "^7.0.13"
   },
   "devDependencies": {
-    "ssb-server": "latest",
+    "ssb-server": "^13.5.2",
     "tape": "^4.2.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var tape = require('tape')
 var ssbKeys = require('ssb-keys')
-var ssbServer = require('scuttlebot')
-  .use(require('scuttlebot/plugins/master'))
+var ssbServer = require('ssb-server')
+  .use(require('ssb-server/plugins/master'))
 
 var ssbClient = require('../')
 


### PR DESCRIPTION
I noticed ssb-client was using an old multiserver, so I've freshened it up:
- `multiserver` 3 (brings it in line with sbot)
- also updated to use `ssb-server@latest` for tests

_backstory: I fell in a hole trying to get scuttle-shell working - was looking at trace wrong and discovered this ancient multiserver dep. I don't know what the implication of changing this version is because I don't know what multiserver is doing here (yet)_