### PR TITLE
Upgrade ssb-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ See [ssb-keys](https://github.com/ssbc/ssb-keys). The keys look like this:
 `caps.shs` is a random string passed to [secret-handshake](https://github.com/auditdrivencrypto/secret-handshake#example). It determines which sbot you are able to connect to. It defaults to a magic string in this repo and also in [scuttlebot](https://github.com/ssbc/scuttlebot/blob/master/lib/ssb-cap.js)
 
 ```js
-var appKey = new Buffer(opts.caps.shs, 'base64')
+var appKey = Buffer.from(opts.caps.shs, 'base64')
 ```
 
 

--- a/client.js
+++ b/client.js
@@ -15,9 +15,9 @@ function toSodiumKeys(keys) {
   if(!keys || !keys.public) return null
   return {
     publicKey:
-      new Buffer(keys.public.replace('.ed25519',''), 'base64'),
+      Buffer.from(keys.public.replace('.ed25519',''), 'base64'),
     secretKey:
-      new Buffer(keys.private.replace('.ed25519',''), 'base64'),
+      Buffer.from(keys.private.replace('.ed25519',''), 'base64'),
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "muxrpc": "^6.4.0",
     "pull-hash": "^1.0.0",
     "pull-stream": "^3.6.0",
-    "ssb-config": "^2.3.9",
+    "ssb-config": "^3.2.5",
     "ssb-keys": "^7.0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
I think (?) that we should bump the major version for this, but I'm not completely sure how the API changed. It seems like our tests pass though?