### PR TITLE
Automatically download manifest from server

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ ssbClient(
         // random string for `appKey` in secret-handshake
         shs: ''
     },
-
-    // optional, muxrpc manifest. Defaults to ~/.ssb/manifest.json
-    manifest: {}       
-
   },
   function (err, sbot, config) {
     // ...
@@ -53,8 +49,6 @@ create a connection to the local `ssb-server` instance, using the default keys.
 configuration and keys will be loaded from directory specified by `ssb_appname`.
 (by default `~/.ssb`)
 
-The manifest will be the manifest provided by that server.
-
 Calling this without arguments is handy for scripts, but applications
 should use the clearer apis.
 
@@ -62,29 +56,28 @@ there is a legacy api, that makes things as "easy" as possible,
 by loading configuration and defaults. This is useful for scripts
 but applications should probably use
 
-##### createEasyClient(keys, opts, cb(err, sbot))
+##### createLegacyClient(keys, opts, cb(err, sbot))
 
 connect to a client with some custom settings.
 
-opts supports the keys:
+The `opts` object supports the keys:
 
 * `remote` multiserver address to connect to
 * `host, port, key` (legacy) if remote is not set, assemble address from host, port, key.
-* `manifest` use a custom manifest.
 
-it's recommended to use the `createClient` api instead, but this is still supported
-for legacy support.
+It's recommended to use the `createEasyClient` instead, but this is still
+available for legacy support.
 
 ### require('ssb-client/client') => createClient
 
-#### createClient({keys, config, manifest, remote}, cb)
+#### createClient({keys, config, remote}, cb)
 
 connect to a specific server with fixed settings. All fields are mandatory.
 
-
-
 ### keys
+
 See [ssb-keys](https://github.com/ssbc/ssb-keys). The keys look like this:
+
 ```js
 {
     id: String,

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ there is a legacy api, that makes things as "easy" as possible,
 by loading configuration and defaults. This is useful for scripts
 but applications should probably use
 
-##### createLegacyClient(keys, opts, cb(err, sbot))
+#### createCustomClient({keys, config, remote}, cb)
+
+Connect to a specific server with fixed settings. All fields are mandatory.
+
+#### createLegacyClient(keys, opts, cb(err, sbot))
 
 connect to a client with some custom settings.
 
@@ -65,14 +69,8 @@ The `opts` object supports the keys:
 * `remote` multiserver address to connect to
 * `host, port, key` (legacy) if remote is not set, assemble address from host, port, key.
 
-It's recommended to use the `createEasyClient` instead, but this is still
-available for legacy support.
-
-### require('ssb-client/client') => createClient
-
-#### createClient({keys, config, remote}, cb)
-
-connect to a specific server with fixed settings. All fields are mandatory.
+If you need custom options it's recommended to use the `createCustomClient` API
+instead, but this is still available for legacy support.
 
 ### keys
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ ssbClient(
         // random string for `appKey` in secret-handshake
         shs: ''
     },
+
+    // Optional muxrpc manifest. Defaults to manifest provided by server.
+    manifest: {}
+
   },
   function (err, sbot, config) {
     // ...
@@ -45,9 +49,11 @@ ssbClient(
 
 #### createEasyClient(cb(err, sbot))
 
-create a connection to the local `ssb-server` instance, using the default keys.
-configuration and keys will be loaded from directory specified by `ssb_appname`.
+Create a connection to the local `ssb-server` instance, using the default keys.
+Configuration and keys will be loaded from directory specified by `ssb_appname`.
 (by default `~/.ssb`)
+
+The manifest will be the manifest provided by that server.
 
 Calling this without arguments is handy for scripts, but applications
 should use the clearer apis.
@@ -56,26 +62,27 @@ there is a legacy api, that makes things as "easy" as possible,
 by loading configuration and defaults. This is useful for scripts
 but applications should probably use
 
-#### createCustomClient({keys, config, remote}, cb)
+##### createCustomClient({keys, config, manifest, remote}, cb(err, sbot))
 
 Connect to a specific server with fixed settings. All fields are mandatory.
 
 #### createLegacyClient(keys, opts, cb(err, sbot))
 
-connect to a client with some custom settings.
+Connect to a client with some custom settings.
 
-The `opts` object supports the keys:
+opts supports the keys:
 
 * `remote` multiserver address to connect to
 * `host, port, key` (legacy) if remote is not set, assemble address from host, port, key.
+* `manifest` use a custom manifest.
 
-If you need custom options it's recommended to use the `createCustomClient` API
-instead, but this is still available for legacy support.
+If you need custom options, it's recommended to use the `createCustomClient` API
+instead, but this is still provided for legacy support.
+
 
 ### keys
 
 See [ssb-keys](https://github.com/ssbc/ssb-keys). The keys look like this:
-
 ```js
 {
     id: String,

--- a/client.js
+++ b/client.js
@@ -6,7 +6,6 @@ var Shs         = require('multiserver/plugins/shs')
 var NoAuth      = require('multiserver/plugins/noauth')
 var UnixSock    = require('multiserver/plugins/unix-socket')
 var explain     = require('explain-error')
-
 var muxrpc      = require('muxrpc')
 var pull        = require('pull-stream')
 
@@ -22,25 +21,26 @@ module.exports = function (opts, cb) {
   var keys = opts.keys
   var remote = opts.remote
   var config = opts.config
+  var manifest = opts.manifest
 
   var shs = Shs({
     keys: toSodiumKeys(keys),
     appKey: opts.config.caps.shs,
 
-    //no client auth. we can't receive connections anyway.
+    // no client auth. we can't receive connections anyway.
     auth: function (cb) { cb(null, false) },
     timeout: config.timers && config.timers.handshake || 3000
   })
 
-  //todo: refactor multiserver so that muxrpc is a transform.
-  //then we can upgrade muxrpc's codec!
+  // todo: refactor multiserver so that muxrpc is a transform.
+  // then we can upgrade muxrpc's codec!
 
   var noauth = NoAuth({
     keys: toSodiumKeys(keys)
   })
 
-  //I think it would be better to make these registerable plugins,
-  //that got connected up when you called. so they are not hard coded here.
+  // I think it would be better to make these registerable plugins,
+  // that got connected up when you called. so they are not hard coded here.
 
   var ms = MultiServer([
     [Net({}), shs],
@@ -51,7 +51,7 @@ module.exports = function (opts, cb) {
   ])
 
   ms.client(remote, function (err, stream) {
-    if(err) {
+    if (err) {
       return cb(explain(err, 'could not connect to sbot'))
     }
 
@@ -60,11 +60,7 @@ module.exports = function (opts, cb) {
     // feeds are ed25519, but will cause problems in the future.
     const remoteId = `@${stream.remote.toString('base64')}.ed25519`
 
-    const sbot = muxrpc((err) => {
-      if (err) {
-        return cb(err)
-      }
-
+    const patch = (sbot) => {
       // fix blobs.add. (see ./util/fix-add-blob.js)
       if (sbot.blobs && sbot.blobs.add) {
         sbot.blobs.add = fixBlobsAdd(sbot.blobs.add)
@@ -78,8 +74,26 @@ module.exports = function (opts, cb) {
         sbot.id = opts.keys.id
       }
 
-      cb(null, sbot, config)
-    }, false, null, remoteId)
+      return sbot
+    }
+
+    // Call `cb()` during the callback when no manifest is passed.
+    if (manifest == null) {
+      manifest = (err) => {
+        if (err) {
+          return cb(err)
+        }
+
+        cb(null, patch(sbot), config)
+      }
+    }
+
+    const sbot = muxrpc(manifest, false, null, remoteId)
+
+    // Explicitly call `cb()` when an explicit manifest is passed.
+    if (typeof manifest !== 'function') {
+      cb(null, patch(sbot), config)
+    }
 
     pull(stream, sbot.stream, stream)
   })

--- a/client.js
+++ b/client.js
@@ -66,12 +66,12 @@ module.exports = function (opts, cb) {
         sbot.blobs.add = fixBlobsAdd(sbot.blobs.add)
       }
 
-      // This refers to the *local* feed ID, and gives us a quick and easy way
-      // to reference ourselves without calling `whoami()`. These may share a
+      // This refers to the *remote* feed ID, and gives us a quick and easy way
+      // to reference the server without calling `whoami()`. These may share a
       // value when the client and server share an identity, but won't be the
-      // same when connecting to a remote server.
+      // same when connecting to a remote server with a different identity.
       if (sbot.id == null) {
-        sbot.id = opts.keys.id
+        sbot.id = remoteId
       }
 
       return sbot

--- a/index.js
+++ b/index.js
@@ -1,53 +1,53 @@
 'use strict'
-var path        = require('path')
-var ssbKeys     = require('ssb-keys')
-var explain     = require('explain-error')
-var fs          = require('fs')
-
+var path         = require('path')
+var ssbKeys      = require('ssb-keys')
 var createConfig = require('ssb-config/inject')
+
 var createClient = require('./client')
 
 module.exports = function (keys, opts, cb) {
   var config
-  if (typeof keys == 'function') {
+  if (typeof keys === 'function') {
     cb = keys
     keys = null
     opts = null
-  }
-  else if (typeof opts == 'function') {
+  } else if (typeof opts === 'function') {
     cb = opts
     opts = keys
     keys = null
   }
-  if(typeof opts === 'string' || opts == null || !keys)
-    config = createConfig((typeof opts === 'string' ? opts : null) || process.env.ssb_appname)
-  else if(opts && 'object' === typeof opts)
+  if (typeof opts === 'string' || opts == null || !keys) {
+    config = createConfig(
+      (typeof opts === 'string' ? opts : null) || process.env.ssb_appname
+    )
+  } else if (opts && typeof opts === 'object') {
     config = opts
+  }
 
   keys = keys || ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))
   opts = opts || {}
 
   var remote
-  if(opts.remote)
-    remote = opts.remote
-  else {
+  if (opts.remote) { remote = opts.remote } else {
     var host = opts.host || 'localhost'
     var port = opts.port || config.port || 8008
     var key = opts.key || keys.id
 
     var protocol = 'net:'
-    if (host.endsWith(".onion"))
-        protocol = 'onion:'
-    remote = protocol+host+':'+port+'~shs:'+key.substring(1).replace('.ed25519', '')
+    if (host.endsWith('.onion')) {
+      protocol = 'onion:'
+    }
+
+    const trimmedKey = key.substring(1).replace('.ed25519', '')
+    remote = `${protocol}${host}:${port}~shs:${trimmedKey}`
   }
+
+  var manifest = opts.manifest || null
 
   createClient({
     keys: keys,
+    manifest: manifest,
     config: config,
     remote: remote
   }, cb)
-
 }
-
-
-

--- a/index.js
+++ b/index.js
@@ -41,19 +41,8 @@ module.exports = function (keys, opts, cb) {
     remote = protocol+host+':'+port+'~shs:'+key.substring(1).replace('.ed25519', '')
   }
 
-  var manifest = opts.manifest || (function () {
-    try {
-      return JSON.parse(fs.readFileSync(
-        path.join(config.path, 'manifest.json')
-      ))
-    } catch (err) {
-      throw explain(err, 'could not load manifest file')
-    }
-  })()
-
   createClient({
     keys: keys,
-    manifest: manifest,
     config: config,
     remote: remote
   }, cb)

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,30 @@ tape('explicit manifest', function (t) {
   })
 })
 
+tape('explicit incorrect manifest', function (t) {
+  const server = ssbServer({
+    port: 45451,
+    timeout: 2001,
+    temp: 'connect',
+    host: 'localhost',
+    master: keys.id,
+    keys: keys,
+    caps: { shs: shsCap }
+  })
+  server.on('multiserver:listening', () => {
+    ssbClient(keys, { port: 45451, manifest: { foo: 'async' }, caps: { shs: shsCap } }, function (err, client) {
+      if (err) throw err
+
+      t.equal(typeof client.foo, 'function')
+      t.equal(typeof client.whoami, 'undefined')
+      t.end()
+
+      client.close(true)
+      server.close(true)
+    })
+  })
+})
+
 tape('automatic manifest', function (t) {
   const server = ssbServer({
     port: 45451,

--- a/test/index.js
+++ b/test/index.js
@@ -19,18 +19,21 @@ var server = ssbServer({
 
 tape('connect', function (t) {
   server.on('multiserver:listening', () => {
-    ssbClient(keys, { port: 45451, manifest: server.manifest(), caps: { shs: shsCap }}, function (err, client) {
+    ssbClient(keys, {
+      port: 45451,
+      caps: { shs: shsCap }
+    }, function (err, client) {
       if (err) throw err
 
       client.whoami(function (err, info) {
-	if (err) throw err
+        if (err) throw err
 
-	console.log('whoami', info)
-	t.equal(info.id, keys.id)
-	t.end()
-	client.close(true)
-	server.close(true)
-	process.exit(0)
+        console.log('whoami', info)
+        t.equal(info.id, keys.id)
+        t.end()
+        client.close(true)
+        server.close(true)
+        process.exit(0)
       })
     })
   })

--- a/test/index.js
+++ b/test/index.js
@@ -8,21 +8,19 @@ var ssbClient = require('../')
 var shsCap = 'XMHDXXFGBJvloCk8fOinzPkKMRqyA2/eH+3VyUr6lig='
 
 var keys = ssbKeys.generate()
-var server = ssbServer({
-  port: 45451, timeout: 2001,
-  temp: 'connect',
-  host: 'localhost',
-  master: keys.id,
-  keys: keys,
-  caps: {shs: shsCap}
-})
 
-tape('connect', function (t) {
+tape('explicit manifest', function (t) {
+  const server = ssbServer({
+    port: 45451,
+    timeout: 2001,
+    temp: 'connect',
+    host: 'localhost',
+    master: keys.id,
+    keys: keys,
+    caps: { shs: shsCap }
+  })
   server.on('multiserver:listening', () => {
-    ssbClient(keys, {
-      port: 45451,
-      caps: { shs: shsCap }
-    }, function (err, client) {
+    ssbClient(keys, { port: 45451, manifest: server.manifest(), caps: { shs: shsCap } }, function (err, client) {
       if (err) throw err
 
       client.whoami(function (err, info) {
@@ -33,7 +31,33 @@ tape('connect', function (t) {
         t.end()
         client.close(true)
         server.close(true)
-        process.exit(0)
+      })
+    })
+  })
+})
+
+tape('automatic manifest', function (t) {
+  const server = ssbServer({
+    port: 45451,
+    timeout: 2001,
+    temp: 'connect',
+    host: 'localhost',
+    master: keys.id,
+    keys: keys,
+    caps: { shs: shsCap }
+  })
+  server.on('multiserver:listening', () => {
+    ssbClient(keys, { port: 45451, caps: { shs: shsCap } }, function (err, client) {
+      if (err) throw err
+
+      client.whoami(function (err, info) {
+        if (err) throw err
+
+        console.log('whoami', info)
+        t.equal(info.id, keys.id)
+        t.end()
+        client.close(true)
+        server.close(true)
       })
     })
   })


### PR DESCRIPTION
Manifests are hard and the server is happy to provide one for us.

This simplifies ssb-client to remove the `manifest` option, using muxrpc's [manifest bootstrap](https://github.com/ssbc/muxrpc/pull/56) instead of asking the user or storing one at `~/.ssb/manifest.json`.

I don't think we want to support any use-case where the client has a different manifest than the server, please correct me if I'm wrong.