### PR TITLE
Add basic support (and tests) for promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,24 @@ module.exports = function (keys, opts, cb) {
   }
 
   var manifest = opts.manifest || null
-
-  createClient({
+  const options = {
     keys: keys,
     manifest: manifest,
     config: config,
     remote: remote
-  }, cb)
+  }
+
+  if (typeof cb === 'function') {
+    createClient(options, cb)
+  } else {
+    return new Promise((resolve, reject) => {
+      createClient(options, (err, val) => {
+	if (err) {
+	  reject(err)
+	} else {
+	  resolve(val)
+	}
+      })
+    })
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "explain-error": "^1.0.1",
     "multicb": "^1.2.1",
     "multiserver": "^3.1.2",
-    "muxrpc": "^6.4.8",
+    "muxrpc": "^6.5.0",
     "pull-hash": "^1.0.0",
     "pull-stream": "^3.6.0",
-    "ssb-config": "^3.2.5",
-    "ssb-keys": "^7.0.13"
+    "ssb-config": "^3.4.4",
+    "ssb-keys": "^7.2.1"
   },
   "devDependencies": {
     "ssb-master": "^1.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -86,3 +86,26 @@ tape('automatic manifest', function (t) {
     })
   })
 })
+
+
+tape('automatic manifest with promise support', function (t) {
+  const server = ssbServer({
+    port: 45451,
+    timeout: 2001,
+    temp: 'connect',
+    host: 'localhost',
+    master: keys.id,
+    keys: keys,
+    caps: { shs: shsCap }
+  })
+  server.on('multiserver:listening', () => {
+    ssbClient(keys, { port: 45451, caps: { shs: shsCap } }).then((client) => {
+      client.whoami().then((info) => {
+        t.equal(info.id, keys.id)
+        t.end()
+        client.close(true)
+        server.close(true)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Problem: The MuxRPC module now supports promises but SSB-Client hadn't
updated `package.json` yet so we couldn't guarantee promise support.
SSB-Client also uses a callback to start, which is hard to use if you
want to use promises everywhere.

Solution: Add the option to use promises everywhere! This adds an
upgrade to `package.json`, tests for the new MuxRPC behavior, and also
adds a promise-based option for starting SSB-Client. Note that this
doesn't add documentation because I see another big documentation PR
open and I don't want to step on toes / make merge conflicts.