### PR TITLE
Only instanciate multiserver plugins that are actually needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "explain-error": "^1.0.1",
     "multicb": "^1.2.1",
     "multiserver": "^3.1.2",
+    "multiserver-address": "^1.0.1",
     "muxrpc": "^6.5.0",
     "pull-hash": "^1.0.0",
     "pull-stream": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "devDependencies": {
     "ssb-master": "^1.0.2",
     "ssb-server": "^14.1.2",
+    "ssb-onion": "^1.0.0",
+    "ssb-unix-socket": "^1.0.0",
+    "ssb-ws": "^6.2.3",
     "tape": "^4.2.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/test/transports.js
+++ b/test/transports.js
@@ -1,0 +1,83 @@
+const tape = require('tape')
+const ssbKeys = require('ssb-keys')
+const pull = require('pull-stream')
+const ssbServer = require('ssb-server')
+  .use(require('ssb-server/plugins/no-auth'))
+  .use(require('ssb-master'))
+  .use(require('ssb-ws'))
+  .use(require('ssb-unix-socket'))
+  .use(require('ssb-onion'))
+
+const ssbClient = require('../')
+
+const shsCap = 'XMHDXXFGBJvloCk8fOinzPkKMRqyA2/eH+3VyUr6lig='
+
+const keys = ssbKeys.generate()
+
+// ssb-server does not support more than one unix socket server 
+// (if there's more than one, they end up having the same file system path, because ssb.config.path is used for this)
+// That's why we create a new server for each transport
+//
+// More problems:
+// - a 2nd unix socket cannot be created by the same process? Even when created by a different multi-server instnace after the
+// You can uncomment one or the other unix incomings below, but not both!
+// first instance was closed?
+// - I can't get the onion stuff to work here. I don't see why.
+
+const incomings = {
+  //"unix-shs": {transport: 'unix', opts: {transform: "shs", scope: "device"}},
+  "net-shs": {transport: 'net', opts: {transform: "shs", scope: "device", port: 45451}},
+  "ws-shs": {transport: 'ws', opts: {transform: "shs", scope: "device", port: 45452}},
+  //"onion-shs": {transport: 'onion', opts: {transform: "shs", scope: "private"}},
+  "unix-noauth": {transport: 'unix', opts: {transform: "noauth", scope: "device"}}
+}
+
+for (let [testname, incoming] of Object.entries(incomings)) {
+  tape(testname, t =>{
+    let {transport, opts} = incoming
+    makeServer(transport, testname, opts, (err, server) =>{
+      const address = server.getAddress("device")
+      console.log('a server is listening on: %s', address)
+      t.pass()
+      server.close(()=>t.end())
+    })
+  })
+}
+
+/*
+tape.skip('net', function (t) {
+    ssbClient(keys, { remote: address, manifest: server.manifest(), caps: { shs: shsCap } }, function (err, client) {
+      if (err) throw err
+
+      client.whoami(function (err, info) {
+        if (err) throw err
+
+        console.log('whoami', info)
+        t.equal(info.id, keys.id)
+        t.end()
+        client.close(true)
+      })
+    })
+  })
+})
+*/
+
+function makeServer(transport, testname, opts, cb) {
+  const server = ssbServer({
+    timeout: 2001,
+    temp: 'connect-' + testname,
+    master: keys.id,
+    keys: keys,
+    caps: { shs: shsCap },
+    connections: {
+      incoming: {
+        [transport]: [opts]
+      }
+    }
+  })
+
+  server.on('multiserver:listening', () => {
+    cb (null, server)
+  })
+}
+


### PR DESCRIPTION
Hey!
Since multiserver 3.7.0 was published I ran into an issue using ssb-client from within a browser context. ssb-client is instanciating multiserver's unix-sockets plugin regardless of whether it is needed to connect to the given remote or not. This used to be fine until multiserver 3.7.0, where, during initialisation of that plugin, a fs function is called that is not replaced by browserify's brfs (mkdtmpSync). While this could be fixed in multiserver, I decided to atteck the root problem instead.

This PR builds a custom Multiserver instance that only instanciates the plugins that are mentioned on the remote address that we want to connect to. It still only allows for the transport/protocol combinations that were previously hardcoded.

What do you think?